### PR TITLE
[Feat] 점프 조건 개발 및 플랫폼 감지 시스템 추가

### DIFF
--- a/Assets/PHG/Scripts/Enemy.meta
+++ b/Assets/PHG/Scripts/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 127fad4d214fc864484749cd925f5f24
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/AttackState.cs
+++ b/Assets/PHG/Scripts/Enemy/AttackState.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PHG;
+public class AttackState : IState
+{
+    private readonly MonsterBrain brain;
+    public AttackState(MonsterBrain brain) => this.brain = brain;
+
+    public void Enter() => brain.ChangeState(StateID.Chase); // 즉시 추격으로 복귀
+    public void Tick() { }                                  // 비워둠
+    public void Exit() { }
+}

--- a/Assets/PHG/Scripts/Enemy/AttackState.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/AttackState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a9a9f4a32dd3c1e40b95f32a7766821c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/ChaseState.cs
+++ b/Assets/PHG/Scripts/Enemy/ChaseState.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using PHG;
+public class ChaseState : IState
+{
+    private readonly MonsterBrain brain;
+    private readonly Rigidbody2D rb;
+    private readonly Transform tf;
+    private readonly Transform player;
+    private readonly JumpMove jumper;
+
+    public ChaseState(MonsterBrain brain)
+    {
+        this.brain = brain;
+        rb = brain.GetComponent<Rigidbody2D>();
+        tf = brain.transform;
+        player = GameObject.FindWithTag("Player")?.transform;
+        jumper = brain.GetComponent<JumpMove>();
+    }
+
+    public void Enter() { }
+
+    public void Tick()
+    {
+        if (player == null)
+        {
+            brain.ChangeState(StateID.Idle);
+            return;
+        }
+
+        float distX = player.position.x - tf.position.x;
+        float distY = player.position.y - tf.position.y;
+        int dir = distX > 0 ? 1 : -1;
+
+        tf.localScale = new Vector3(dir, 1, 1);
+
+        if (Mathf.Abs(rb.velocity.y) > 0.1f) return;
+
+        if (Mathf.Abs(distX) <= brain.attackRange)
+        {
+            rb.velocity = Vector2.zero;
+            brain.ChangeState(StateID.Attack);
+            return;
+        }
+
+        if (Mathf.Abs(distX) > brain.chaseRange)
+        {
+            rb.velocity = Vector2.zero;
+            brain.ChangeState(StateID.Idle);
+            return;
+        }
+
+        bool wallAhead = Physics2D.Raycast(brain.sensor.position, Vector2.right * dir, 0.15f, brain.groundMask);
+        bool yAbove = distY > 0.8f;
+        bool jumpableAbove = jumper != null && jumper.IsPlatformAbove();
+
+        if (jumper != null)
+        {
+            if (wallAhead)
+            {
+                if (jumper.TryJumpWallOrPlatform(dir)) return;
+            }
+            else if (yAbove && jumpableAbove)
+            {
+                if (jumper.TryJumpToPlatformAbove(dir, player.position)) return;
+            }
+        }
+
+        rb.velocity = new Vector2(dir * brain.moveSpeed, rb.velocity.y);
+    }
+
+    public void Exit() => rb.velocity = Vector2.zero;
+}

--- a/Assets/PHG/Scripts/Enemy/ChaseState.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/ChaseState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d348687ab95bc84581885152f2c5083
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/Core.meta
+++ b/Assets/PHG/Scripts/Enemy/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ac300c21d32a124c86d68193023a044
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/Core/IState.cs
+++ b/Assets/PHG/Scripts/Enemy/Core/IState.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PHG;
+public interface IState
+{
+    void Enter(); // 상태 진입 1회
+    void Tick(); // 매 프레임(또는 Fixed) 호출
+    void Exit(); // 상태 종료 1회
+
+}

--- a/Assets/PHG/Scripts/Enemy/Core/IState.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/Core/IState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1df5d75a6d50f040b37637ea19b4e34
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/Core/StateID.cs
+++ b/Assets/PHG/Scripts/Enemy/Core/StateID.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+/// <summary>
+/// 몬스터 FSM 상태 식별자
+/// </summary>
+/// 
+namespace PHG
+{
+    public enum StateID
+    {
+        Idle,
+        Chase,
+        Attack,
+        Dead
+    }
+}

--- a/Assets/PHG/Scripts/Enemy/Core/StateID.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/Core/StateID.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9aeffa2727241af42a9e362d387db8b3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/Core/StateMachine.cs
+++ b/Assets/PHG/Scripts/Enemy/Core/StateMachine.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PHG;
+public class StateMachine
+{
+    private readonly Dictionary<StateID, IState> states = new();
+    private IState current;
+
+    public void Register(StateID id, IState state) => states[id] = state;
+
+    public void ChangeState(StateID next)
+    {
+        if (!states.TryGetValue(next, out var target)) return;
+        current?.Exit();
+        current = target;
+        current.Enter();
+    }
+    public void Tick() => current?.Tick();
+}

--- a/Assets/PHG/Scripts/Enemy/Core/StateMachine.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/Core/StateMachine.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21734637bfdc2714090e1d3b7b23e519
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/DeadState.cs
+++ b/Assets/PHG/Scripts/Enemy/DeadState.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PHG;
+public class DeadState : IState
+{
+    private readonly MonsterBrain brain;
+    public DeadState(MonsterBrain brain) => this.brain = brain;
+
+    public void Enter() => Object.Destroy(brain.gameObject);
+    public void Tick() { }
+    public void Exit() { }
+
+
+}

--- a/Assets/PHG/Scripts/Enemy/DeadState.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/DeadState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 98b2ada09c408a8409c98918d1d1783e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/JumpMove.cs
+++ b/Assets/PHG/Scripts/Enemy/JumpMove.cs
@@ -1,0 +1,124 @@
+using UnityEngine;
+using PHG;
+[RequireComponent(typeof(Rigidbody2D))]
+public class JumpMove : MonoBehaviour
+{
+    [Header("점프 설정")]
+    [SerializeField] private float jumpCooldown = 0.8f;
+    [SerializeField] private float jumpForce = 6f;
+    [SerializeField] private float forwardImpulse = 2.5f;
+
+    [Header("센서 및 마스크")]
+    [SerializeField] private Transform platformSensor;
+    [SerializeField] private Vector2 platformBoxSize = new(1.3f, 1f);
+    [SerializeField] private LayerMask groundMask;
+    [SerializeField] private LayerMask jumpableMask;
+
+    private Rigidbody2D rb;
+    private float timer;
+
+    private void Awake() => rb = GetComponent<Rigidbody2D>();
+
+    public bool TryJumpWallOrPlatform(int dir)
+    {
+        if (!Ready()) return false;
+
+        // 1. 벽 감지
+        Vector2 wallOrigin = (Vector2)transform.position + new Vector2(dir * 0.25f, 0f);
+        bool wallAhead = Physics2D.Raycast(wallOrigin, Vector2.right * dir, 0.1f, groundMask);
+        Debug.DrawRay(wallOrigin, Vector2.right * 0.1f, Color.magenta);
+
+        // 2. 플랫폼 감지
+        bool platformAbove = IsPlatformAbove();
+
+        Debug.Log($"[JUMP] 점프 조건 wall:{wallAhead}, platform:{platformAbove}");
+
+        if (wallAhead || platformAbove)
+        {
+            // 점프 전 위치 보정 → 벽에 붙는 현상 방지
+            Vector2 jumpOrigin = (Vector2)transform.position + new Vector2(dir * 0.2f, 0f);
+            rb.position = jumpOrigin;
+            return DoJump(dir);
+        }
+
+        return false;
+    }
+
+    public bool TryJumpToPlatformAbove(int dir, Vector2 targetPos)
+    {
+        if (!Ready()) return false;
+
+        float yDiff = targetPos.y - transform.position.y;
+        if (yDiff < 0.5f) return false;
+
+        // [1] 센서 위치 임시 보정
+        Vector3 originalPos = platformSensor.localPosition;
+        platformSensor.localPosition = new Vector3(originalPos.x, Mathf.Clamp(yDiff, 1.1f, 3f), originalPos.z);
+
+        // [2] 플랫폼 감지
+        bool platformAbove = IsPlatformAbove();
+
+        // [3] 원위치 복구
+        platformSensor.localPosition = originalPos;
+        if (!platformAbove) return false;
+
+        // [4] 점프력 보정
+        float heightScale = Mathf.Clamp01(yDiff / 3f);
+        float adjustedJump = Mathf.Lerp(jumpForce * 0.8f, jumpForce * 1.6f, heightScale);
+
+        // 점프 전 위치 보정
+        Vector2 jumpOrigin = (Vector2)transform.position + new Vector2(dir * 0.2f, 0f);
+        rb.position = jumpOrigin;
+
+        return DoJumpWithForce(dir, adjustedJump, forwardImpulse);
+    }
+
+    private bool DoJumpWithForce(int dir, float yForce, float xImpulse)
+    {
+        rb.velocity = new Vector2(rb.velocity.x, 0);
+        rb.AddForce(Vector2.up * yForce, ForceMode2D.Impulse);
+        rb.AddForce(Vector2.right * dir * xImpulse, ForceMode2D.Impulse);
+        timer = 0;
+        return true;
+    }
+
+    public bool IsPlatformAbove()
+    {
+        if (platformSensor == null) return false;
+        Collider2D platform = Physics2D.OverlapBox(platformSensor.position, platformBoxSize, 0f, jumpableMask);
+        return platform != null;
+    }
+
+    private bool Ready()
+    {
+        timer += Time.deltaTime;
+        return timer >= jumpCooldown && IsGrounded();
+    }
+
+    private bool DoJump(int dir)
+    {
+        rb.velocity = new Vector2(rb.velocity.x, 0);
+        rb.AddForce(Vector2.up * jumpForce, ForceMode2D.Impulse);
+        rb.AddForce(Vector2.right * dir * forwardImpulse, ForceMode2D.Impulse);
+        timer = 0;
+        return true;
+    }
+
+    private bool IsGrounded()
+    {
+        bool grounded = Physics2D.Raycast(transform.position, Vector2.down, 0.3f, groundMask);
+        Debug.DrawRay(transform.position, Vector2.down * 0.3f, grounded ? Color.green : Color.red);
+        return grounded;
+    }
+
+#if UNITY_EDITOR
+    private void OnDrawGizmosSelected()
+    {
+        if (platformSensor != null)
+        {
+            Gizmos.color = Color.magenta;
+            Gizmos.DrawWireCube(platformSensor.position, platformBoxSize);
+        }
+    }
+#endif
+}

--- a/Assets/PHG/Scripts/Enemy/JumpMove.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/JumpMove.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a6273e8af0f7bcd419eb1cd5178991e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/MonsterBrain.cs
+++ b/Assets/PHG/Scripts/Enemy/MonsterBrain.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using PHG;
+
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class MonsterBrain : MonoBehaviour
+{
+
+    [Header("Sensor/Mask")]
+    public Transform sensor; //ÇÏÀ§ ºó gameObject
+    public LayerMask groundMask; // groundLayer ÁöÁ¤
+
+    private StateMachine sm;
+
+    private PatrolState patrol;
+    private ChaseState chase;
+    private AttackState attack;
+    private DeadState dead;
+
+    private void Awake()
+    {
+        patrol = new PatrolState(this);
+        chase = new ChaseState(this);
+        attack = new AttackState(this);
+        dead = new DeadState(this);
+
+        sm = new StateMachine();
+        sm.Register(StateID.Idle, patrol);
+        sm.Register(StateID.Chase, chase);
+        sm.Register(StateID.Attack, attack);
+        sm.Register(StateID.Dead, dead);
+
+        sm.ChangeState(StateID.Idle);
+    }
+    private void FixedUpdate() => sm.Tick();
+
+    [Header("Params")]
+    public float moveSpeed = 2f;
+    public float patrolRange = 3f;
+    public float chaseRange = 6f;
+    public float attackRange = 1f;
+
+    public void ChangeState(StateID id) => sm.ChangeState(id);
+
+
+
+
+
+}

--- a/Assets/PHG/Scripts/Enemy/MonsterBrain.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/MonsterBrain.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2dae5e51a72bbf542beff9a847a53edb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/MonsterDebugGizmos.cs
+++ b/Assets/PHG/Scripts/Enemy/MonsterDebugGizmos.cs
@@ -1,0 +1,73 @@
+﻿using UnityEngine;
+using PHG;
+#if UNITY_EDITOR
+using UnityEditor;        // Handles
+#endif
+
+[ExecuteAlways]
+[RequireComponent(typeof(MonsterBrain))]
+public class MonsterDebugGizmos : MonoBehaviour
+{
+    /* ───────── 레퍼런스 캐싱 ───────── */
+    private MonsterBrain brain;
+    private JumpMove jumper;
+
+    private void OnEnable()
+    {
+        brain = GetComponent<MonsterBrain>();
+        jumper = GetComponent<JumpMove>();      // 없으면 null
+    }
+
+#if UNITY_EDITOR
+    private void OnDrawGizmos()
+    {
+        if (brain == null || brain.sensor == null) return;
+
+        float dir = Mathf.Sign(transform.localScale.x); // 바라보는 방향 (+/-)
+
+        /*──────────────── 센서 레이 ────────────────*/
+        // Patrol/Chase ① 바닥 확인
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawLine(brain.sensor.position,
+                        brain.sensor.position + Vector3.down * 0.20f);
+
+        // Patrol/Chase ② 벽 확인
+        Gizmos.color = new Color(1f, 0f, 1f);  // Magenta
+        Gizmos.DrawLine(brain.sensor.position,
+                        brain.sensor.position + Vector3.right * dir * 0.10f);
+
+        // Chase        ③ wallAhead
+        Gizmos.color = Color.red;
+        Gizmos.DrawLine(brain.sensor.position,
+                        brain.sensor.position + Vector3.right * dir * 0.35f);
+
+        /*──────────────── JumpMove 레이 ─────────────*/
+        if (jumper != null)
+        {
+            // 위쪽 점프 가능 플랫폼 감지용 디버그 (새 추가)
+            Gizmos.color = Color.blue;
+            Gizmos.DrawLine(transform.position + Vector3.up * 0.1f,
+                            transform.position + Vector3.up * 1.5f);
+        }
+
+
+        /*──────────────── 원형 감지 범위 ────────────*/
+        Vector3 p = transform.position;
+        if (brain.patrolRange > 0f)
+        {
+            Handles.color = new Color(0f, 0.6f, 1f, 0.35f);             // 하늘색
+            Handles.DrawWireDisc(p, Vector3.forward, brain.patrolRange);
+        }
+        if (brain.chaseRange > 0f)
+        {
+            Handles.color = new Color(1f, 0.85f, 0f, 0.35f);            // 노랑
+            Handles.DrawWireDisc(p, Vector3.forward, brain.chaseRange);
+        }
+        if (brain.attackRange > 0f)
+        {
+            Handles.color = new Color(1f, 0f, 0f, 0.35f);              // 빨강
+            Handles.DrawWireDisc(p, Vector3.forward, brain.attackRange);
+        }
+    }
+#endif
+}

--- a/Assets/PHG/Scripts/Enemy/MonsterDebugGizmos.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/MonsterDebugGizmos.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3b2584caa33b1bc4ea56ec653e799871
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Enemy/PatrolState.cs
+++ b/Assets/PHG/Scripts/Enemy/PatrolState.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using PHG;
+/// <summary>
+/// ←→ 왕복으로 순찰하다가 플레이어가 가까워지면 추적 상태로 전환
+/// </summary>
+public class PatrolState : IState
+{
+    private readonly MonsterBrain brain;
+    private readonly Rigidbody2D rb;
+    private readonly Transform tf;
+    private readonly Transform sensor;
+    private readonly LayerMask groundMask;
+
+    private int dir = 1; // 1= -> , -1 = <-
+    private const float floorCheckDist = 0.2f; //발아래 확인
+    private const float wallCheckDist = 0.1f; //벽 확인 거리
+
+    public PatrolState(MonsterBrain brain)
+    {
+        this.brain = brain;
+        rb = brain.GetComponent<Rigidbody2D>(); //  몬스터 rigidbody 캐싱
+        tf = brain.transform;
+
+        // MonsterBrain 인스펙터에 Sensor, GrounMask 노출
+        sensor = brain.sensor;
+        groundMask = brain.groundMask;
+    }
+    /*========= IState 인터페이스 구현 =========*/
+    public void Enter() { }   // 처음 들어올 때 할 일 없음
+    public void Tick()
+    {
+        /** 1) 이동 코드 ---------------------------------- */
+        //  dir(±1) * 이동속도로 X방향 속도 부여
+        rb.velocity = new Vector2(dir * brain.moveSpeed, rb.velocity.y);
+
+        /* 낭떠러지, 벽감지 -> 방향 반전 */
+        bool noFloor = !Physics2D.Raycast(sensor.position, Vector2.down, floorCheckDist, groundMask);
+        bool hitWall = Physics2D.Raycast(sensor.position, Vector2.right * dir, wallCheckDist, groundMask);
+
+        if(noFloor || hitWall)
+        {
+            dir *= -1; // 방향 반전
+            tf.localScale = new Vector3(dir, 1, 1);
+            //sensor가 항상 앞을 향하도록
+        }
+        /* 3) (옵션) 추적 전환 */
+         if (PlayerInRange(brain.patrolRange)) brain.ChangeState(StateID.Chase);
+
+    }
+    // 상태를 떠날 때 이동 중지
+    public void Exit() => rb.velocity = Vector2.zero;
+
+    /*──────────────── 헬퍼 메서드 ────────────────*/
+    private bool PlayerInRange(float range)
+    {
+        var player = GameObject.FindWithTag("Player");
+        if (player == null) return false;
+        return Vector2.Distance(tf.position, player.transform.position) <= range;
+    }
+
+
+}

--- a/Assets/PHG/Scripts/Enemy/PatrolState.cs.meta
+++ b/Assets/PHG/Scripts/Enemy/PatrolState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e740b3d08d6c8a843b1d814cd5ef7671
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Player.meta
+++ b/Assets/PHG/Scripts/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 477595f56e59ab54e94909e1cbe87fa3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/PHG/Scripts/Player/PlayerController.cs
+++ b/Assets/PHG/Scripts/Player/PlayerController.cs
@@ -1,0 +1,63 @@
+// PlayerController2D.cs
+using UnityEngine;
+using PHG;
+/// <summary>
+/// 기본 이동·점프 컨트롤러
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D), typeof(CapsuleCollider2D))]
+public class PlayerController2D : MonoBehaviour
+{
+    /* ──────────────── Member 변수 ──────────────── */
+    [SerializeField] private float moveSpeed = 5f;          // ←→ 이동 속도
+    [SerializeField] private float jumpForce = 12f;         // 점프 힘
+    [SerializeField] private LayerMask groundMask;          // 지면 레이어
+    [SerializeField] private Transform groundCheck;         // 발 아래 체크 위치
+    [SerializeField] private float groundCheckRadius = 0.15f;
+
+    /* ──────────────── Private ──────────────── */
+    private Rigidbody2D rb;
+    private bool isGrounded;
+
+    /* ──────────────── Unity Lifecycle ──────────────── */
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        rb.freezeRotation = true;               // 2D 평면 고정
+    }
+
+    private void Update()
+    {
+        Move(Input.GetAxisRaw("Horizontal"));
+        if (Input.GetKeyDown(KeyCode.Space) && isGrounded) Jump();
+    }
+
+    private void FixedUpdate() => CheckGround();
+
+    /* ──────────────── Core ──────────────── */
+    private void Move(float dir /* 매개변수 */)
+    {
+        rb.velocity = new Vector2(dir * moveSpeed, rb.velocity.y);
+        if (dir != 0) transform.localScale = new Vector3(Mathf.Sign(dir), 1, 1); // 좌우 뒤집기
+    }
+
+    private void Jump()
+    {
+        rb.velocity = new Vector2(rb.velocity.x, 0);        // 점프 전 Y속도 리셋
+        rb.AddForce(Vector2.up * jumpForce, ForceMode2D.Impulse);
+    }
+
+    private void CheckGround()
+    {
+        isGrounded = Physics2D.OverlapCircle(groundCheck.position, groundCheckRadius, groundMask);
+    }
+
+#if UNITY_EDITOR
+    // 에디터에서 GroundCheck 시각화
+    private void OnDrawGizmosSelected()
+    {
+        if (groundCheck == null) return;
+        Gizmos.color = Color.green;
+        Gizmos.DrawWireSphere(groundCheck.position, groundCheckRadius);
+    }
+#endif
+}

--- a/Assets/PHG/Scripts/Player/PlayerController.cs.meta
+++ b/Assets/PHG/Scripts/Player/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bb2e79c62a2b9749845976ae938b6b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
■ 주요 개발 사항
- Monster FSM의 ChaseState에 점프 조건 분기 세분화
  - 벽 감지 및 Jumpable 플랫폼 레이어 인식 시 자동 점프 시도
  - 플랫폼 추적을 위한 y값 기반 점프력 보정 시스템 구현
- JumpMove.cs에 스마트 점프 로직 통합
  - OverlapBox를 통한 플랫폼 탐지 센서 도입
  - 점프 센서 위치와 점프력 보정 로직 적용
  - 점프 오프셋 적용 (벽에 붙어서 점프 시 반동 방지)
- 디버그용 기즈모 시각화 추가 및 플랫폼센서 연동
- 네임스페이스 구조화 준비 (PHG 도입에 따른 정리 전단계)

■ 테스트 및 확인 사항
- 플레이어가 Jumpable 플랫폼 위에 있어도 추적/점프 가능
- 벽 앞에서는 점프 후 자연스럽게 경로 유지
- gap/낙하에 대한 오탐지 제거 (조건 단순화)

■ TODO (다음 작업)
- StateID 및 FSM 관련 클래스 네임스페이스 적용
- 플랫폼 위치에 따라 점프 곡선 조정 보완